### PR TITLE
Trim trailing whitespace in multi-line comments

### DIFF
--- a/edge/format.js
+++ b/edge/format.js
@@ -1096,6 +1096,7 @@ function format(content, options = {}) {
 						} else {
 							commentLines[zeroBasedLineIndex] = ' *' + spaceAfterComment + commentLines[zeroBasedLineIndex]
 						}
+						commentLines[zeroBasedLineIndex] = _.trimEnd(commentLines[zeroBasedLineIndex])
 					}
 				}
 

--- a/spec/option-insert-space-after-comment-true/input.styl
+++ b/spec/option-insert-space-after-comment-true/input.styl
@@ -5,3 +5,11 @@ body//comment-2
 /*comment-4*/
 .class1/*comment-5*/
   display none/*comment-6*/
+
+/**
+ * comment-7 
+ * 
+ * comment-8 
+ */
+.class2
+  display none

--- a/spec/option-insert-space-after-comment-true/output.styl
+++ b/spec/option-insert-space-after-comment-true/output.styl
@@ -7,3 +7,12 @@ body { // comment-2
 .class1 { /* comment-5 */
 	display: none; /* comment-6 */
 }
+
+/**
+ * comment-7
+ *
+ * comment-8
+ */
+.class2 {
+	display: none;
+}


### PR DESCRIPTION
Currently, setting `insertSpaceAfterComment` to `true` causes "blank" lines (i.e. starts with `*`) in multi-line comments to have a trailing space. This change ensures that all of lines are properly trimmed.